### PR TITLE
fix loop size halve and double in hybrid MIDI mode

### DIFF
--- a/src/single-deck/Denon-SC3900/Deck1.midi.xml
+++ b/src/single-deck/Denon-SC3900/Deck1.midi.xml
@@ -222,7 +222,7 @@
             <control>
                 <group>[Channel1]</group>
                 <key>loop_halve</key>
-                <description>Halve loop size on loop - button press.</description>
+                <description>Halve loop size on loop - button press (in Normal MIDI mode).</description>
                 <status>0x90</status>
                 <midino>0x69</midino>
                 <options>
@@ -232,11 +232,21 @@
             <control>
                 <group>[Channel1]</group>
                 <key>loop_double</key>
-                <description>Double loop size on loop + button press.</description>
+                <description>Double loop size on loop + button press (in Normal MIDI mode).</description>
                 <status>0x90</status>
                 <midino>0x6A</midino>
                 <options>
                     <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>DenonSC3900.onHybridMidiModeLoopSizeHalveOrDouble</key>
+                <description>Halve or double loop size on loop - / + button press (in Hybrid MIDI mode).</description>
+                <status>0xB0</status>
+                <midino>0x55</midino>
+                <options>
+                    <script-binding/>
                 </options>
             </control>
             <control>

--- a/src/single-deck/Denon-SC3900/scripts.js
+++ b/src/single-deck/Denon-SC3900/scripts.js
@@ -12,6 +12,9 @@ DenonSC3900.AUTO_LOOP_WRITE_ADDRESS = 0x2B
 DenonSC3900.A_LOOP_LIGHT_WRITE_ADDRESS = 0X24
 DenonSC3900.B_LOOP_LIGHT_WRITE_ADDRESS = 0X40
 
+DenonSC3900.HYBRID_MIDI_LOOP_HALVE_VALUE = 0x7F
+DenonSC3900.HYBRID_MIDI_LOOP_DOUBLE_VALUE = 0x00
+
 DenonSC3900.HOTCUES_WRITE_ADDRESSES = {
     1: {
         light: 0x11,
@@ -353,6 +356,24 @@ DenonSC3900.shutdown = function () {
             DenonSC3900.getOutputMidiChannel(channel)
         );
     }
+}
+
+// #############################################################################
+// ## Loop management
+// #############################################################################
+
+// only triggered in hybrid MIDI mode
+DenonSC3900.onHybridMidiModeLoopSizeHalveOrDouble = function (channel, control, value, status, group) {
+    if (value !== DenonSC3900.HYBRID_MIDI_LOOP_HALVE_VALUE && value !== DenonSC3900.HYBRID_MIDI_LOOP_DOUBLE_VALUE) {
+        return;
+    }
+
+    var action = value === DenonSC3900.HYBRID_MIDI_LOOP_HALVE_VALUE
+        ? 'loop_halve'
+        : 'loop_double'
+    ;
+
+    engine.setValue(group, action, true);
 }
 
 // #############################################################################


### PR DESCRIPTION
The loop - and + buttons aren't sending the same messages in normal and
hybrid MIDI mode, thus the binding for the hybrid MIDI mode wasn't
present untill this commit.
These changes make sure we can use this loop size change feature in
hybrid MIDI mode.