### PR TITLE
fix wrong hotcue light state when replacing a track on a deck

### DIFF
--- a/src/single-deck/Denon-SC3900/Deck1.midi.xml
+++ b/src/single-deck/Denon-SC3900/Deck1.midi.xml
@@ -472,147 +472,91 @@
             </output>
             <output>
                 <group>[Channel1]</group>
-                <key>hotcue_1_enabled</key>
-                <description>Turn on hotcue 1 dimmer light.</description>
+                <key>hotcue_1_position</key>
+                <description>Manages hotcue 1 light (dimmer or fully on)</description>
                 <status>0xB0</status>
                 <midino>0x4A</midino>
                 <on>0x12</on>
-                <maximum>0</maximum>
+                <off>0x11</off>
+                <minimum>-1.0</minimum>
+                <maximum>-1.0</maximum>
             </output>
             <output>
                 <group>[Channel1]</group>
-                <key>hotcue_2_enabled</key>
-                <description>Turn on hotcue 2 dimmer light.</description>
+                <key>hotcue_2_position</key>
+                <description>Manages hotcue 2 light (dimmer or fully on)</description>
                 <status>0xB0</status>
                 <midino>0x4A</midino>
                 <on>0x14</on>
-                <maximum>0</maximum>
+                <off>0x13</off>
+                <minimum>-1.0</minimum>
+                <maximum>-1.0</maximum>
             </output>
             <output>
                 <group>[Channel1]</group>
-                <key>hotcue_3_enabled</key>
-                <description>Turn on hotcue 3 dimmer light.</description>
+                <key>hotcue_3_position</key>
+                <description>Manages hotcue 3 light (dimmer or fully on)</description>
                 <status>0xB0</status>
                 <midino>0x4A</midino>
                 <on>0x16</on>
-                <maximum>0</maximum>
+                <off>0x15</off>
+                <minimum>-1.0</minimum>
+                <maximum>-1.0</maximum>
             </output>
             <output>
                 <group>[Channel1]</group>
-                <key>hotcue_4_enabled</key>
-                <description>Turn on hotcue 4 dimmer light.</description>
+                <key>hotcue_4_position</key>
+                <description>Manages hotcue 4 light (dimmer or fully on)</description>
                 <status>0xB0</status>
                 <midino>0x4A</midino>
                 <on>0x18</on>
-                <maximum>0</maximum>
+                <off>0x17</off>
+                <minimum>-1.0</minimum>
+                <maximum>-1.0</maximum>
             </output>
             <output>
                 <group>[Channel1]</group>
-                <key>hotcue_5_enabled</key>
-                <description>Turn on hotcue 1 (MIDIBANK2) dimmer light.</description>
+                <key>hotcue_5_position</key>
+                <description>Manages hotcue 5 light (dimmer or fully on)</description>
                 <status>0xB0</status>
                 <midino>0x4A</midino>
                 <on>0x32</on>
-                <maximum>0</maximum>
+                <off>0x31</off>
+                <minimum>-1.0</minimum>
+                <maximum>-1.0</maximum>
             </output>
             <output>
                 <group>[Channel1]</group>
-                <key>hotcue_6_enabled</key>
-                <description>Turn on hotcue 2 (MIDIBANK2) dimmer light.</description>
+                <key>hotcue_6_position</key>
+                <description>Manages hotcue 6 light (dimmer or fully on)</description>
                 <status>0xB0</status>
                 <midino>0x4A</midino>
                 <on>0x34</on>
-                <maximum>0</maximum>
+                <off>0x33</off>
+                <minimum>-1.0</minimum>
+                <maximum>-1.0</maximum>
             </output>
             <output>
                 <group>[Channel1]</group>
-                <key>hotcue_7_enabled</key>
-                <description>Turn on hotcue 3 (MIDIBANK2) dimmer light.</description>
+                <key>hotcue_7_position</key>
+                <description>Manages hotcue 7 light (dimmer or fully on)</description>
                 <status>0xB0</status>
                 <midino>0x4A</midino>
                 <on>0x36</on>
-                <maximum>0</maximum>
+                <off>0x35</off>
+                <minimum>-1.0</minimum>
+                <maximum>-1.0</maximum>
             </output>
             <output>
                 <group>[Channel1]</group>
-                <key>hotcue_8_enabled</key>
-                <description>Turn on hotcue 4 (MIDIBANK2) dimmer light.</description>
+                <key>hotcue_8_position</key>
+                <description>Manages hotcue 8 light (dimmer or fully on)</description>
                 <status>0xB0</status>
                 <midino>0x4A</midino>
                 <on>0x38</on>
-                <maximum>0</maximum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>hotcue_1_enabled</key>
-                <description>Turn on hotcue 1 light when set.</description>
-                <status>0xB0</status>
-                <midino>0x4A</midino>
-                <on>0x11</on>
-                <minimum>1</minimum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>hotcue_2_enabled</key>
-                <description>Turn on hotcue 2 light when set.</description>
-                <status>0xB0</status>
-                <midino>0x4A</midino>
-                <on>0x13</on>
-                <minimum>1</minimum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>hotcue_3_enabled</key>
-                <description>Turn on hotcue 3 light when set.</description>
-                <status>0xB0</status>
-                <midino>0x4A</midino>
-                <on>0x15</on>
-                <minimum>1</minimum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>hotcue_4_enabled</key>
-                <description>Turn on hotcue 4 light when set.</description>
-                <status>0xB0</status>
-                <midino>0x4A</midino>
-                <on>0x17</on>
-                <minimum>1</minimum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>hotcue_5_enabled</key>
-                <description>Turn on hotcue 1 (MIDIBANK2) light when set.</description>
-                <status>0xB0</status>
-                <midino>0x4A</midino>
-                <on>0x31</on>
-                <minimum>1</minimum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>hotcue_6_enabled</key>
-                <description>Turn on hotcue 2 (MIDIBANK2) light when set.</description>
-                <status>0xB0</status>
-                <midino>0x4A</midino>
-                <on>0x33</on>
-                <minimum>1</minimum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>hotcue_7_enabled</key>
-                <description>Turn on hotcue 3 (MIDIBANK2) light when set.</description>
-                <status>0xB0</status>
-                <midino>0x4A</midino>
-                <on>0x35</on>
-                <minimum>1</minimum>
-            </output>
-            <output>
-                <group>[Channel1]</group>
-                <key>hotcue_8_enabled</key>
-                <description>Turn on hotcue 4 (MIDIBANK2) light when set.</description>
-                <status>0xB0</status>
-                <midino>0x4A</midino>
-                <on>0x37</on>
-                <minimum>1</minimum>
+                <off>0x37</off>
+                <minimum>-1.0</minimum>
+                <maximum>-1.0</maximum>
             </output>
             <output>
                 <group>[Channel1]</group>


### PR DESCRIPTION
This commit fixes the following unexpected behavior :

- Load a track on deck A which has hotcue1 set. The SC3900 hotcue1
  button lights fully.
- Replace the track of deck A with another track which also has hotcue1
  set : the SC3900 hotcue1 button lights with backlight (dimmer) only,
  whereas it should light up fully as the hotcue1 is set in mixxx.

To fix this, we rely on the `hotcue_X_position` mixxx attribute instead
of the `hotcue_X_enabled` attribute. The position attribute has a `-1.0`
value when the hotcue is not set, so we can use this value with the `on`
and `off` XML config keys in order to send the correct value for the
button light (i.e. dimmer or fully on) to the SC3900.

See https://github.com/mixxxdj/mixxx/blob/release-2.2.4/src/controllers/midi/midioutputhandler.cpp#L43-L46

Notice that this unexpected behavior was only occuring for the first
hotcue light config exposed in the XML mapping (e.g. when the config for
the hotcue1 was removed, the behavior was occuring only to the hotcue2).
So this bug may also be related to how mixxx parses the mapping file,
but I have no clues about that.