### PR TITLE
fix hotcue press handler condition

### DIFF
--- a/src/single-deck/Denon-SC3900/scripts.js
+++ b/src/single-deck/Denon-SC3900/scripts.js
@@ -312,9 +312,7 @@ DenonSC3900.onClrButtonRelease = function () {
 DenonSC3900.onHotcuePress = function (group, hotcueNumber) {
     var action = DenonSC3900.clrButtonPressed
         ? "clear"
-        : (DenonSC3900.isHotcueSet(group, hotcueNumber) && !DenonSC3900.isPlaying(group))
-            ? "goto"
-            : "activate"
+        : "activate"
     ;
 
     var valueName = "hotcue_" + hotcueNumber + "_" + action;


### PR DESCRIPTION
The condition when pressing a hotcue button was most of the time ending
to the `activate` action, which handles by itself the `set` or `goto`
behaviors, so there is no need for such condition after all.