### PR TITLE
Revert "fix hotcue press handler condition"

### DIFF
--- a/src/single-deck/Denon-SC3900/scripts.js
+++ b/src/single-deck/Denon-SC3900/scripts.js
@@ -312,7 +312,9 @@ DenonSC3900.onClrButtonRelease = function () {
 DenonSC3900.onHotcuePress = function (group, hotcueNumber) {
     var action = DenonSC3900.clrButtonPressed
         ? "clear"
-        : "activate"
+        : (DenonSC3900.isHotcueSet(group, hotcueNumber) && !DenonSC3900.isPlaying(group))
+            ? "goto" // handles `goto` behavior while paused
+            : "activate" // handles `goto` behavior while playing and `set` behaviors while playing/paused
     ;
 
     var valueName = "hotcue_" + hotcueNumber + "_" + action;


### PR DESCRIPTION
This reverts commit bf9b8db0a5d104d55194fba544a5d217390563a4.

The condition was actually required as the `activate` actions doesn't
handles the `goto` cuepoint while paused behavior.

This commit adds a note detailing why the condition is required.